### PR TITLE
Modify the SMS API to upsert a Reminder document when a Courtbot VT user subscribes to receiving a court notification.

### DIFF
--- a/pages/api/sms/[instance]/index.ts
+++ b/pages/api/sms/[instance]/index.ts
@@ -135,10 +135,19 @@ const handleText = async (req:NextApiRequest, res:NextApiResponse, input:string,
           // let's check for a yes
           if (response.toLowerCase() === 'yes') {
             let c = cases[0];
-            await ReminderDao.create({
+            await ReminderDao.updateOne({
               uid: c.uid,
               number: c.number,
               phone,
+            },
+            {
+              uid: c.uid,
+              number: c.number,
+              phone,
+              active: true
+            },
+            {
+              upsert: true
             });
 
             logger.info(`${phone} (${instance})[${state}]: reminder set`, { metadata: {
@@ -179,10 +188,19 @@ const handleText = async (req:NextApiRequest, res:NextApiResponse, input:string,
           // if a number was given lets check to see if it maps to a case index
           if (response === parseInt(response).toString() && index >= 0 && index < cases.length) {
             let c = cases[index];
-            await ReminderDao.create({
+            await ReminderDao.updateOne({
               uid: c.uid,
               number: c.number,
               phone,
+            },
+            {
+              uid: c.uid,
+              number: c.number,
+              phone,
+              active: true
+            },
+            {
+              upsert: true
             });
 
             logger.info(`${phone} (${instance})[${state}]: reminder set`, { metadata: {


### PR DESCRIPTION
Unit tests for this pull request are not included in this pull request, but are available [here](https://github.com/NathanWEdwards/courtbot-vt-test/blob/test/courtbot-vt-frontend/pages/api/sms/%5Binstance%5D/index.test.ts).

This request proposes the SMS API be modified such that when a user elects to receive a notification on an upcoming court session, a single document is updated (or inserted) through an updateOne() Mongoose call having options.upsert set to true.

Currently, when a user subscribes to being reminded on an upcoming court session, a new Reminder document is added each time.

The requested change may impose unwanted side-effects if duplicate Reminder documents are not removed.

Exempli gratia (Where _id is the group _id from the aggregate operation and not the reminder document _id):

```
db.reminders.aggregate(
    [
        { "$group": {
             "_id" : {
                "uid": "$uid",
                "number": "$number",
                "phone": "$phone",
                },
            "active": { "$addToSet": "$active" }
        }},
        {   "$project": {
                "active": "$active",
                "count": {
                    "$size": "$active"
                    }
        }}
    ]
)
```

Reminder documents with matching phone number and court case docket identifiers and numbers (but with multiple, different active states) will have more than one active field value in the following group operation:

```
  {
    _id: {
      uid: 'County-Probate-114-178-120-litigant-10',
      number: '114-178-120',
      phone: '+11234567890'
    },
    active: [ true, false ],
    count: 2
  }
```

One side-effect of the current implementation is that users may be notified multiple times on an upcoming court session if a users makes multiple confirmations to receive a notification on an upcoming court date, as a Reminder document is currently created each time a user subscribes. Duplicate Reminder documents from the MongoDB store may be removed with:

```
db.reminders.aggregate(
    [
        { "$group": {
            "_id" : {
                "uid": "$uid",
                "number": "$number",
                "phone": "$phone",
                "active": "$active",
            },
            "reminder": { "$first": "$$ROOT" }
        }},
        { "$project": {
            "_id": "$reminder._id",
            "uid": "$reminder.uid",
            "number": "$reminder.number",
            "phone": "$reminder.phone",
            "active": "$reminder.active",
            "createdAt": "$reminder.createdAt",
            "updatedAt": "$reminder.updatedAt"
        }},
        { "$out": "reminders" }
    ]
)
```

User stories:

Given a user is subscribing to receive a notification on a court case for the first time,
when a user does **declines** to be notified on an upcoming court session and the SMS API is called,
then no Reminder document is created.


Given a user is subscribing to receive a notification on a court case for the first time,
when a user confirms to be notified on an upcoming court session and the SMS API is called,
then a single Reminder document is created with the associated case's unique identifier and user phone number and the Reminder document's active field is set to true.


Given a user is subscribing to receive a notification on a court case that they have been notified on prior and **one** associated Reminder document exists with its active field value set to false,
when a user confirms to be notified on an upcoming court session and the SMS API is called,
then the associated Reminder document having a matching case unique identifier and user phone number is updated with the document's active field set to true.


Given a user has subscribed to receiving a notification on an upcoming court session and **one** associated Reminder document exists with its active field value set to true,
when a user confirms to be notified on the same upcoming court session and the SMS API is called,
no additional Reminder document is created and the associated Reminder document's unique case identifier and user phone number and active field value set to true field states are not modified.


Acceptance criterion:

A Reminder document is created when a user confirms to receiving a notification on an upcoming court date for a valid court case for the first time.


An associated Reminder document's active field is updated to true when a user confirms to receiving a notification on a court date for a valid court case the user has previously received a notification.


No additional Reminder documents are created when a user confirms to receiving a notification on an upcoming court date for a valid court case multiple times.